### PR TITLE
fix issue of not providing filters argument name in topn query

### DIFF
--- a/pilosa/orm.py
+++ b/pilosa/orm.py
@@ -464,7 +464,7 @@ class Frame:
         if field:
             validate_label(field)
             values_str = json.dumps(values, separators=(',', ': '))
-            parts.extend(["field='%s'" % field, values_str])
+            parts.extend(["field='%s'" % field, "filters=%s" % values_str])
         qry = u"TopN(%s)" % ", ".join(parts)
         return PQLQuery(qry, self.index)
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -290,12 +290,12 @@ class FrameTestCase(unittest.TestCase):
 
         q3 = sampleFrame.topn(12, collabFrame.bitmap(7), "category", 80, 81)
         self.assertEquals(
-            "TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=false, field='category', [80,81])",
+            "TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=false, field='category', filters=[80,81])",
             q3.serialize())
 
         q4 = sampleFrame.inverse_topn(12, collabFrame.bitmap(7), "category", 80, 81)
         self.assertEquals(
-            "TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=true, field='category', [80,81])",
+            "TopN(Bitmap(project=7, frame='collaboration'), frame='sample-frame', n=12, inverse=true, field='category', filters=[80,81])",
             q4.serialize())
 
     def test_range(self):


### PR DESCRIPTION
The `filters` argument name should be provided in the `TopN` query or an error results:

```python
>>> client.query(frame.topn(1, None, 'name', 'bob'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bmuller/.virtualenvs/pensieve/lib/python3.6/site-packages/pilosa/client.py", line 116, in query
    raise PilosaError(query_response.error_message)
pilosa.exceptions.PilosaError: expected argument key, found "[" occurred at line 1, char 60
```

This pull request simply adds the argument name.  Tests were updated to reflect this.