### PR TITLE
TRIVIAL: Convert the protobuf data to a byte array before posting it

### DIFF
--- a/pilosa/client.py
+++ b/pilosa/client.py
@@ -110,7 +110,7 @@ class Client(object):
         :rtype: pilosa.Response
         """
         request = _QueryRequest(query.serialize(), columns=columns, exclude_bits=exclude_bits, exclude_attrs=exclude_attrs)
-        data = request.to_protobuf()
+        data = bytearray(request.to_protobuf())
         path = "/index/%s/query" % query.index.name
         response = self.__http_request("POST", path, data, Client.__RAW_RESPONSE)
         query_response = QueryResponse._from_protobuf(response.data)


### PR DESCRIPTION
Convert the protobuf data to a byte array before posting it in order to avoid unicode decode errors.

The CI build fail, since some tests requires server features which aren't yet released. Running the tests locally passes on Py 2.7 and 3.5.