### PR TITLE
Fix TopN query generation when attrName/attrValues specified

### DIFF
--- a/pilosa/orm.py
+++ b/pilosa/orm.py
@@ -437,7 +437,7 @@ class Field:
         fmt = u"Clear(%s,%s=%s)"
         return PQLQuery(fmt % (col_str, self.name, row_str), self.index)
 
-    def topn(self, n, row=None, field="", *values):
+    def topn(self, n, row=None, name="", *values):
         """Creates a TopN query.
 
         ``TopN`` returns the id and count of the top n rows (by count of columns) in the field.
@@ -446,17 +446,17 @@ class Field:
 
         :param int n: number of items to return
         :param pilosa.PQLQuery row: a PQL Row query
-        :param field str field: field name
-        :param object values: filter values to be matched against the field
+        :param str name: only return rows which have the attribute specified by attribute name
+        :param object values: filter values to be matched against the attribute name
         """
         parts = [self.name]
         if row:
             parts.append(row.serialize())
         parts.append("n=%d" % n)
-        if field:
-            validate_label(field)
+        if name:
+            validate_label(name)
             values_str = json.dumps(values, separators=(',', ': '))
-            parts.extend(["field='%s'" % field, "filters=%s" % values_str])
+            parts.extend(["attrName='%s'" % name, "attrValues=%s" % values_str])
         qry = u"TopN(%s)" % ",".join(parts)
         return PQLQuery(qry, self.index)
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -325,7 +325,7 @@ class FieldTestCase(unittest.TestCase):
 
         q3 = sampleField.topn(12, collabField.row(7), "category", 80, 81)
         self.assertEquals(
-            u"TopN(sample-field,Row(collaboration=7),n=12,field='category',filters=[80,81])",
+            u"TopN(sample-field,Row(collaboration=7),n=12,attrName='category',attrValues=[80,81])",
             q3.serialize())
 
     def test_range(self):


### PR DESCRIPTION
Per the docs [here](https://www.pilosa.com/docs/latest/query-language/#topn), the attribute names should be `attrName` and `attrValues`.  I can confirm this is the only way it works with Pilosa v1.0.2