### PR TITLE
Fix connect_timeout and socket_timeout adjustment on re-use.

### DIFF
--- a/pilosa/client.py
+++ b/pilosa/client.py
@@ -368,6 +368,11 @@ class Client(object):
             # don't copy these
             if k in ["cluster", "logger"]:
                 continue
+            # because these get divided by 1000.0 in __init__ to be in seconds, we
+            # have to change them to milliseconds before using them again in Client()
+            if k in ["connect_timeout", "socket_timeout"]:
+                client_params[k] = 1000.0 * v
+                continue
             client_params[k] = v
         for node in nodes:
             client = Client(URI.address(node.url), **client_params)


### PR DESCRIPTION
The Client class divides incoming connect_timeout and socket_timeout by
1000.0 before storing those values as a member variables in __init__.
The import_field function calls _import_data, which instantiates a new
Client with existing values, which causes the timeouts to be divided by
1000.0 again in the new client, causing unintended timeouts.

This PR adjusts the values back to milliseconds before they get adjusted
again in __init__.

Fixes #151 