### PR TITLE
fix NoneType Error when pass either 'from_' or 'to' in row query(#153)

### DIFF
--- a/pilosa/orm.py
+++ b/pilosa/orm.py
@@ -624,12 +624,12 @@ class Field:
     def _row_range(self, row, start, end):
         """Creates a Row query with timestamps."""
         row_str = idkey_as_str(row)
-        start_str = start.strftime(_TIME_FORMAT)
-        end_str = end.strftime(_TIME_FORMAT)
         parts = ['%s=%s' % (self.name, row_str)]
         if start:
+            start_str = start.strftime(_TIME_FORMAT)
             parts.append("from='%s'" % start_str)
         if end:
+            end_str = end.strftime(_TIME_FORMAT)
             parts.append("to='%s'" % end_str)
         return PQLQuery(u"Row(%s)" % ','.join(parts), self.index)
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -401,6 +401,32 @@ class FieldTestCase(unittest.TestCase):
             u"Row(collaboration='b7feb014-8ea7-49a8-9cd8-19709161ab63',from='1970-01-01T00:00',to='2000-02-02T03:04')",
             q3.serialize().query)
 
+    def test_row_range_only_from(self):
+        start = datetime(1970, 1, 1, 0, 0)
+        q1 = collabField.row(10, from_=start)
+        self.assertEquals(
+            u"Row(collaboration=10,from='1970-01-01T00:00')",
+            q1.serialize().query
+        )
+
+        q3 = collabField.row("b7feb014-8ea7-49a8-9cd8-19709161ab63", from_=start)
+        self.assertEquals(
+            u"Row(collaboration='b7feb014-8ea7-49a8-9cd8-19709161ab63',from='1970-01-01T00:00')",
+            q3.serialize().query)
+
+    def test_row_range_only_to(self):
+        end = datetime(2000, 2, 2, 3, 4)
+        q1 = collabField.row(10, to=end)
+        self.assertEquals(
+            u"Row(collaboration=10,to='2000-02-02T03:04')",
+            q1.serialize().query
+        )
+
+        q3 = collabField.row("b7feb014-8ea7-49a8-9cd8-19709161ab63", to=end)
+        self.assertEquals(
+            u"Row(collaboration='b7feb014-8ea7-49a8-9cd8-19709161ab63',to='2000-02-02T03:04')",
+            q3.serialize().query)
+
     def test_set_row_attributes(self):
         attrs_map = {
             "quote": '''"Don't worry, be happy"''',


### PR DESCRIPTION
#153 
Since both `from_` and `or` are optional, We could pass either `from_` or `to` to the row query. However, `start` and `end` variables are initialized in the wrong order before the following judgement.