### PR TITLE
Fix connect_timeout and socket_timeout adjustment on Client construction

### DIFF
--- a/pilosa/client.py
+++ b/pilosa/client.py
@@ -117,8 +117,8 @@ class Client(object):
         * See `Pilosa Python Client/Server Interaction <https://github.com/pilosa/python-pilosa/blob/master/docs/server-interaction.md>`_.
         """
         self.use_manual_address = use_manual_address
-        self.connect_timeout = connect_timeout / 1000.0
-        self.socket_timeout = socket_timeout / 1000.0
+        self.connect_timeout = connect_timeout
+        self.socket_timeout = socket_timeout
         self.pool_size_per_route = pool_size_per_route
         self.pool_size_total = pool_size_total
         self.retry_count = retry_count
@@ -467,7 +467,7 @@ class Client(object):
             'User-Agent': 'python-pilosa/%s' % VERSION,
         }
 
-        timeout = urllib3.Timeout(connect=self.connect_timeout, read=self.socket_timeout)
+        timeout = urllib3.Timeout(connect=self.connect_timeout / 1000.0, read=self.socket_timeout / 1000.0)
         client_options = {
             "num_pools": num_pools,
             "maxsize": self.pool_size_per_route,

--- a/pilosa/client.py
+++ b/pilosa/client.py
@@ -467,7 +467,9 @@ class Client(object):
             'User-Agent': 'python-pilosa/%s' % VERSION,
         }
 
-        timeout = urllib3.Timeout(connect=self.connect_timeout / 1000.0, read=self.socket_timeout / 1000.0)
+        connect_timeout_in_seconds = self.connect_timeout / 1000.0
+        socket_timeout_in_seconds = self.socket_timeout / 1000.0
+        timeout = urllib3.Timeout(connect=connect_timeout_in_seconds, read=socket_timeout_in_seconds)
         client_options = {
             "num_pools": num_pools,
             "maxsize": self.pool_size_per_route,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,6 +71,21 @@ class ClientTestCase(unittest.TestCase):
         }
         self.assertEquals(target, options)
 
+    def test_timeout_stay_same_after_recreate(self):
+        prev_client = Client()
+        client_params = {}
+        for k, v in prev_client.__dict__.items():
+            # don't copy protected, private params
+            if k.startswith("_"):
+                continue
+            # don't copy these
+            if k in ["cluster", "logger"]:
+                continue
+            client_params[k] = v
+
+        new_client = Client(**client_params)
+        self.assertEquals(prev_client.connect_timeout, new_client.connect_timeout)
+        self.assertEquals(prev_client.socket_timeout, new_client.socket_timeout)
 
 
 class URITestCase(unittest.TestCase):


### PR DESCRIPTION
# Overview

Fix `connect_timeout` and `socket_timeout` adjustment on Client construction

Fixes: https://github.com/pilosa/python-pilosa/issues/151

# Notes

timeout unit adjustments ` / 1000.0` are needed only for `urllib3.Timeout` object
there is no need to perform those divisions on Client construction
doing ` / 1000.0` at Client constructor introduces bug mentioned at https://github.com/pilosa/python-pilosa/issues/151

that change will solve issue when client is recreated with previous params while running `_import_data` function
[here](https://github.com/pilosa/python-pilosa/blob/1e7c08a8efa5cefac9f60a03f32b3a447c4be8f0/pilosa/client.py#L364)
where timeout is incrementally decreased on each client recreation

## Travis CI failure not related to that change, same failure happens in master

failure relates to incompatibility with python 3.9 for `import_field` function with `fast_import` flag set to `True`
